### PR TITLE
Avoid using dynamic table names in migration

### DIFF
--- a/db/migrations/20170530124319_add_pending_index_table.php
+++ b/db/migrations/20170530124319_add_pending_index_table.php
@@ -3,8 +3,6 @@
 use Phinx\Migration\AbstractMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-use Pragma\Search\PendingIndexCol;
-
 class AddPendingIndexTable extends AbstractMigration
 {
 		/**
@@ -31,7 +29,7 @@ class AddPendingIndexTable extends AbstractMigration
 		public function change(){
 			if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 				$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-				$t = $this->table(PendingIndexCol::getTableName(), ['id' => false, 'primary_key' => 'id']);
+				$t = $this->table('pending_indexs', ['id' => false, 'primary_key' => 'id']);
 				switch($strategy){
 					case 'mysql':
 						$t->addColumn('id', 'char', ['limit' => 36])
@@ -47,7 +45,7 @@ class AddPendingIndexTable extends AbstractMigration
 				}
 			}
 			else{
-				$t = $this->table(PendingIndexCol::getTableName());
+				$t = $this->table('pending_indexs');
 				$t->addColumn('historisable_type', 'char', ['limit' => 60])
 					->addColumn('indexable_type', 'char', ['limit' => 60])
 					->addColumn('indexable_id', 'integer');

--- a/db/migrations/20170530190325_create_index_keywords_table.php
+++ b/db/migrations/20170530190325_create_index_keywords_table.php
@@ -2,8 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Search\Keyword;
-
 class CreateIndexKeywordsTable extends AbstractMigration
 {
 		/**
@@ -30,7 +28,7 @@ class CreateIndexKeywordsTable extends AbstractMigration
 		public function change(){
 			if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 				$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-				$t = $this->table(Keyword::getTableName(), ['id' => false, 'primary_key' => 'id']);
+				$t = $this->table('keywords', ['id' => false, 'primary_key' => 'id']);
 				switch($strategy){
 					case 'mysql':
 						$t->addColumn('id', 'char', ['limit' => 36]);
@@ -42,7 +40,7 @@ class CreateIndexKeywordsTable extends AbstractMigration
 				}
 			}
 			else{
-				$t = $this->table(Keyword::getTableName());
+				$t = $this->table('keywords');
 			}
 
 			$t->addColumn('word', 'char', ['limit' => 64])

--- a/db/migrations/20170530202154_create_indexes_table.php
+++ b/db/migrations/20170530202154_create_indexes_table.php
@@ -2,8 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Search\Index;
-
 class CreateIndexesTable extends AbstractMigration
 {
 		/**
@@ -30,7 +28,7 @@ class CreateIndexesTable extends AbstractMigration
 		public function change(){
 			if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 				$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-				$t = $this->table(Index::getTableName(), ['id' => false, 'primary_key' => 'id']);
+				$t = $this->table('indexes', ['id' => false, 'primary_key' => 'id']);
 				switch($strategy){
 					case 'mysql':
 						$t->addColumn('id', 'char', ['limit' => 36])
@@ -50,7 +48,7 @@ class CreateIndexesTable extends AbstractMigration
 				}
 			}
 			else{
-				$t = $this->table(Index::getTableName());
+				$t = $this->table('indexes');
 				$t->addColumn('keyword_id', 'integer')
 					->addColumn('context_id', 'integer')
 					->addColumn('indexable_type', 'char', ['limit' => 60])

--- a/db/migrations/20170531055536_create_classes_to_index_table.php
+++ b/db/migrations/20170531055536_create_classes_to_index_table.php
@@ -2,8 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Search\Indexed;
-
 class CreateClassesToIndexTable extends AbstractMigration
 {
 		/**
@@ -30,7 +28,7 @@ class CreateClassesToIndexTable extends AbstractMigration
 		public function change(){
 			if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 				$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-				$t = $this->table(Indexed::getTableName(), ['id' => false, 'primary_key' => 'id']);
+				$t = $this->table('indexed', ['id' => false, 'primary_key' => 'id']);
 				switch($strategy){
 					case 'mysql':
 						$t->addColumn('id', 'char', ['limit' => 36]);
@@ -42,7 +40,7 @@ class CreateClassesToIndexTable extends AbstractMigration
 				}
 			}
 			else{
-					$t = $this->table(Indexed::getTableName());
+					$t = $this->table('indexed');
 			}
 
 			$t->addColumn('classname', 'char', ['limit' => 60])

--- a/db/migrations/20170603061702_create_contexts_table.php
+++ b/db/migrations/20170603061702_create_contexts_table.php
@@ -3,8 +3,6 @@
 use Phinx\Migration\AbstractMigration;
 use Phinx\Db\Adapter\MysqlAdapter;
 
-use Pragma\Search\Context;
-
 class CreateContextsTable extends AbstractMigration
 {
 	/**
@@ -31,7 +29,7 @@ class CreateContextsTable extends AbstractMigration
 	public function change(){
 		if(defined('ORM_ID_AS_UID') && ORM_ID_AS_UID){
 			$strategy = defined('ORM_UID_STRATEGY') && ORM_UID_STRATEGY == 'mysql' ? 'mysql' : 'php';
-			$t = $this->table(Context::getTableName(), ['id' => false, 'primary_key' => 'id']);
+			$t = $this->table('contexts', ['id' => false, 'primary_key' => 'id']);
 			switch($strategy){
 				case 'mysql':
 					$t->addColumn('id', 'char', ['limit' => 36]);
@@ -43,7 +41,7 @@ class CreateContextsTable extends AbstractMigration
 			}
 		}
 		else{
-			$t = $this->table(Context::getTableName());
+			$t = $this->table('contexts');
 		}
 
 		$t->addColumn('context', 'text', ['limit' => MysqlAdapter::TEXT_LONG])

--- a/db/migrations/20170724120904_update_table_keywords.php
+++ b/db/migrations/20170724120904_update_table_keywords.php
@@ -2,8 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Search\Keyword;
-
 class UpdateTableKeywords extends AbstractMigration
 {
     /**
@@ -29,12 +27,12 @@ class UpdateTableKeywords extends AbstractMigration
      */
     public function up()
     {
-        $t = $this->table(Keyword::getTableName());
+        $t = $this->table('keywords');
         $t->changeColumn('word', 'char', ['limit' => 64, 'collation' => 'utf8_bin'])->update();
     }
     public function donw()
     {
-        $t = $this->table(Keyword::getTableName());
+        $t = $this->table('keywords');
         $t->changeColumn('word', 'char', ['limit' => 64, 'collation' => 'utf8_general_ci'])->update();
     }
 }

--- a/db/migrations/20170925133029_pending_index_add_deleted_col.php
+++ b/db/migrations/20170925133029_pending_index_add_deleted_col.php
@@ -2,8 +2,6 @@
 
 use Phinx\Migration\AbstractMigration;
 
-use Pragma\Search\PendingIndexCol;
-
 class PendingIndexAddDeletedCol extends AbstractMigration
 {
     /**
@@ -29,7 +27,7 @@ class PendingIndexAddDeletedCol extends AbstractMigration
      */
     public function change()
     {
-        $this->table(PendingIndexCol::getTableName())
+        $this->table('pending_indexs')
             ->addColumn('deleted', 'boolean', ['default' => false])
             ->update();
     }

--- a/phinx.php
+++ b/phinx.php
@@ -14,6 +14,7 @@ return array(
             'pass' => DB_PASSWORD,
             'charset' => 'utf8',
             'collation' => 'utf8_general_ci',
+            'table_prefix' => defined('DB_PREFIX') ? DB_PREFIX : 'pragma_',
         ),
     ),
 );


### PR DESCRIPTION
As class declarations table names might be changed  in further updates,
it would invalidate every previous migrations.