### PR TITLE
Keep type hint and allow to pass null value

### DIFF
--- a/Pragma/Search/Keyword.php
+++ b/Pragma/Search/Keyword.php
@@ -38,7 +38,7 @@ class Keyword extends Model{
 		}
 	}
 
-	public function store($context, $classname, $id, $col){
+	public function store(Context $context = null, $classname, $id, $col){
 		Index::build([
 			'keyword_id' 			=> $this->id,
 			'context_id'			=> ! is_null($context) ? $context->id : null,


### PR DESCRIPTION
https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration

	$ php -a
	Interactive mode enabled

	php > function test1(int $foo, int $bar) {
	php {   var_dump($foo);
	php { }

	php > test1(42, 1337);
	int(42)

	php > test1([42], 1337);
	PHP Warning:  Uncaught TypeError: Argument 1 passed to test1() must be of the type integer, array given, called in php shell code on line 1 and defined in php shell code:1
	Stack trace:
	#0 php shell code(1): test1(Array, 1337)
	#1 {main}
	  thrown in php shell code on line 1

	php > test1(null, 1337);
	PHP Warning:  Uncaught TypeError: Argument 1 passed to test1() must be of the type integer, null given, called in php shell code on line 1 and defined in php shell code:1
	Stack trace:
	#0 php shell code(1): test1(NULL, 1337)
	#1 {main}
	  thrown in php shell code on line 1

	php > function test2(int $foo = null, int $bar) {
	php {   var_dump($foo);
	php { }

	php > test2(42, 1337);
	int(42)

	php > test2([42], 1337);
	PHP Warning:  Uncaught TypeError: Argument 1 passed to test2() must be of the type integer, array given, called in php shell code on line 1 and defined in php shell code:1
	Stack trace:
	#0 php shell code(1): test2(Array, 1337)
	#1 {main}
	  thrown in php shell code on line 1

	php > test2(null, 1337);
	NULL